### PR TITLE
Remove errant characters in XML; Add CI Linting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,3 +16,15 @@ jobs:
       - name: Lint XML
         # use `xargs` instead of `find exec` so non-0 exit codes are correctly returned
         run: find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs xmllint --noout
+
+      - name: Check for extra whitespace at the start of elements
+        # use `xargs` instead of `find exec` so non-0 exit codes are correctly returned
+        # invert exit code; grep returns 0 if match (linting issue) found
+        run: |
+          ! find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs grep -P ">\s\w+"
+
+      - name: Check for extra whitespace at the end of elements
+        # use `xargs` instead of `find exec` so non-0 exit codes are correctly returned
+        # invert exit code; grep returns 0 if match (linting issue) found
+        run: |
+          ! find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs grep -P "\w\s+</"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+# continuous integration
+# run tests for repo
+---
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+
+      - name: Lint XML
+        # use `xargs` instead of `find exec` so non-0 exit codes are correctly returned
+        run: find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs xmllint --noout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,17 +14,17 @@ jobs:
         run: sudo apt-get install libxml2-utils
 
       - name: Lint XML
-        # use `xargs` instead of `find exec` so non-0 exit codes are correctly returned
+        # use `xargs` instead of `find -exec` so non-0 exit codes are correctly returned
         run: find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs xmllint --noout
 
       - name: Check for extra whitespace at the start of elements
-        # use `xargs` instead of `find exec` so non-0 exit codes are correctly returned
-        # invert exit code; grep returns 0 if match (linting issue) found
+        # invert exit code; grep normally returns 0 if match (linting issue) found
+        # use `xargs` instead of `find -exec` so non-0 exit codes are correctly returned
         run: |
-          ! find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs grep -P ">\s\w+"
+          ! find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs grep --perl-regexp ">\s\w+"
 
       - name: Check for extra whitespace at the end of elements
-        # use `xargs` instead of `find exec` so non-0 exit codes are correctly returned
-        # invert exit code; grep returns 0 if match (linting issue) found
+        # invert exit code; grep normally returns 0 if match (linting issue) found
+        # use `xargs` instead of `find -exec` so non-0 exit codes are correctly returned
         run: |
-          ! find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs grep -P "\w\s+</"
+          ! find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs grep --perl-regexp "\w\s+</"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,16 +15,29 @@ jobs:
 
       - name: Lint XML
         # use `xargs` instead of `find -exec` so non-0 exit codes are correctly returned
-        run: find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs xmllint --noout
+        run: >
+          find 106/ 20170701/
+          -name "*.xml"
+          ! -name '*invalid*'
+          ! -name '*error*'
+          | xargs xmllint --noout
 
       - name: Check for extra whitespace at the start of elements
         # invert exit code; grep normally returns 0 if match (linting issue) found
         # use `xargs` instead of `find -exec` so non-0 exit codes are correctly returned
-        run: |
-          ! find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs grep --perl-regexp ">\s\w+"
+        run: >
+          ! find 106/ 20170701/
+          -name "*.xml"
+          ! -name '*invalid*'
+          ! -name '*error*'
+          | xargs grep --perl-regexp ">\s\w+"
 
       - name: Check for extra whitespace at the end of elements
         # invert exit code; grep normally returns 0 if match (linting issue) found
         # use `xargs` instead of `find -exec` so non-0 exit codes are correctly returned
-        run: |
-          ! find 106/ 20170701/ -name "*.xml" ! -name '*invalid*' ! -name '*error*' | xargs grep --perl-regexp "\w\s+</"
+        run: >
+          ! find 106/ 20170701/
+          -name "*.xml"
+          ! -name '*invalid*'
+          ! -name '*error*'
+          | xargs grep --perl-regexp "\w\s+</"

--- a/106/elizabeth-browning-1983-05-03.xml
+++ b/106/elizabeth-browning-1983-05-03.xml
@@ -174,7 +174,7 @@ Total MME should be:
 			</MedicationDispensed>
 
 			<MedicationDispensed>
-				<DrugDescription>Suboxone - Buprenorphine/ naloxone sublingual film 2/.5 MG </DrugDescription>
+				<DrugDescription>Suboxone - Buprenorphine/ naloxone sublingual film 2/.5 MG</DrugDescription>
 				<DrugCoded>
 					<ProductCode>00378876593</ProductCode>
 					<ProductCodeQualifier>ND</ProductCodeQualifier>
@@ -391,7 +391,7 @@ Total MME should be:
 
 
 					<MedicationDispensed>
-				<DrugDescription>Methadone 40 mg diskette </DrugDescription>
+				<DrugDescription>Methadone 40 mg diskette</DrugDescription>
 				<DrugCoded>
 					<ProductCode>00054453825</ProductCode>
 					<ProductCodeQualifier>ND</ProductCodeQualifier>

--- a/106/john-cushing-2000-12-10.xml
+++ b/106/john-cushing-2000-12-10.xml
@@ -124,7 +124,7 @@ Total MME should be:
 				</HistorySource>
 			</MedicationDispensed>
 			<MedicationDispensed>
-				<DrugDescription>24 HR hydromorphone hydrochloride 12 MG Extended Release Oral Tablet </DrugDescription>
+				<DrugDescription>24 HR hydromorphone hydrochloride 12 MG Extended Release Oral Tablet</DrugDescription>
 				<DrugCoded>
 					<ProductCode>43602026730</ProductCode>
 					<ProductCodeQualifier>ND</ProductCodeQualifier>

--- a/106/marcus-aurelius-1975-06-17.xml
+++ b/106/marcus-aurelius-1975-06-17.xml
@@ -230,7 +230,7 @@ Total MME should be:
 			<MedicationDispensed>
 				<DrugDescription>MS Cotin 30 MG Oral Tablet</DrugDescription>
 				<DrugCoded>
-					<ProductCode>55700036760 </ProductCode>
+					<ProductCode>55700036760</ProductCode>
 					<ProductCodeQualifier>ND</ProductCodeQualifier>
 				</DrugCoded>
 				<Quantity>
@@ -283,7 +283,7 @@ Total MME should be:
 
 
             <MedicationDispensed>
-				<DrugDescription>Fentanyl Transdermal System, 0.025 mg/hr </DrugDescription>
+				<DrugDescription>Fentanyl Transdermal System, 0.025 mg/hr</DrugDescription>
 				<DrugCoded>
 					<ProductCode>61919060205</ProductCode>
 					<ProductCodeQualifier>ND</ProductCodeQualifier>
@@ -337,7 +337,7 @@ Total MME should be:
 			</MedicationDispensed>
 
             <MedicationDispensed>
-				<DrugDescription>Fentanyl Transdermal System, 0.05 mg/hr </DrugDescription>
+				<DrugDescription>Fentanyl Transdermal System, 0.05 mg/hr</DrugDescription>
 				<DrugCoded>
 					<ProductCode>60505700700</ProductCode>
 					<ProductCodeQualifier>ND</ProductCodeQualifier>
@@ -391,7 +391,7 @@ Total MME should be:
 			</MedicationDispensed>
 
             <MedicationDispensed>
-				<DrugDescription>Fentanyl Transdermal System, 0.075 mg/hr </DrugDescription>
+				<DrugDescription>Fentanyl Transdermal System, 0.075 mg/hr</DrugDescription>
 				<DrugCoded>
 					<ProductCode>00378912316</ProductCode>
 					<ProductCodeQualifier>ND</ProductCodeQualifier>
@@ -446,7 +446,7 @@ Total MME should be:
 
 	
 			<MedicationDispensed>
-				<DrugDescription>Fentanyl Transdermal System, 0.1 mg/hr </DrugDescription>
+				<DrugDescription>Fentanyl Transdermal System, 0.1 mg/hr</DrugDescription>
 				<DrugCoded>
 					<ProductCode>00378912416</ProductCode>
 					<ProductCodeQualifier>ND</ProductCodeQualifier>

--- a/20170701/artful-dodger-2012-04-19.xml
+++ b/20170701/artful-dodger-2012-04-19.xml
@@ -264,7 +264,7 @@
         <DrugDescription>armodafinil 150 MG Oral Tablet [Nuvigil]</DrugDescription>
         <DrugCoded>
           <ProductCode>
-            <Code>63459021530	</Code>
+            <Code>63459021530</Code>
             <Qualifier>ND</Qualifier>
           </ProductCode>
         </DrugCoded>

--- a/20170701/copy-osborn-1974-09-01.xml
+++ b/20170701/copy-osborn-1974-09-01.xml
@@ -636,7 +636,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	1 ML meperidine hydrochloride 100 MG/ML Prefilled Syringe [Demerol]</DrugDescription>
+        <DrugDescription>1 ML meperidine hydrochloride 100 MG/ML Prefilled Syringe [Demerol]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>00409137711</Code>

--- a/20170701/deux-val-1964-07-29.xml
+++ b/20170701/deux-val-1964-07-29.xml
@@ -186,7 +186,7 @@
         </HistorySource>
       </MedicationDispensed>
     <!--  <MedicationDispensed>
-        <DrugDescription>butorphanol 10 MG/ML </DrugDescription>
+        <DrugDescription>butorphanol 10 MG/ML</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>58198004701</Code>
@@ -486,7 +486,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>clonazepam 0.25 MG Disintegrating Oral Tablet </DrugDescription>
+        <DrugDescription>clonazepam 0.25 MG Disintegrating Oral Tablet</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>57664078488</Code>

--- a/20170701/elizabeth-browning-1983-05-03.xml
+++ b/20170701/elizabeth-browning-1983-05-03.xml
@@ -262,7 +262,7 @@
       </MedicationDispensed>
 
       <MedicationDispensed>
-        <DrugDescription>Suboxone - Buprenorphine/ naloxone sublingual film 2/.5 MG </DrugDescription>
+        <DrugDescription>Suboxone - Buprenorphine/ naloxone sublingual film 2/.5 MG</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>00378876593</Code>

--- a/20170701/harry-osborn-1974-09-01.xml
+++ b/20170701/harry-osborn-1974-09-01.xml
@@ -636,7 +636,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	1 ML meperidine hydrochloride 100 MG/ML Prefilled Syringe [Demerol]</DrugDescription>
+        <DrugDescription>1 ML meperidine hydrochloride 100 MG/ML Prefilled Syringe [Demerol]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>00409137711</Code>

--- a/20170701/harry-potter-2016-06-30.xml
+++ b/20170701/harry-potter-2016-06-30.xml
@@ -264,7 +264,7 @@
         <DrugDescription>carisoprodol 350 MG Oral Tablet [Vanadom]</DrugDescription>
         <DrugCoded>
           <ProductCode>
-            <Code>69036092035	</Code>
+            <Code>69036092035</Code>
             <Qualifier>ND</Qualifier>
           </ProductCode>
         </DrugCoded>
@@ -336,7 +336,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	dronabinol 10 MG Oral Capsule [Marinol]</DrugDescription>
+        <DrugDescription>dronabinol 10 MG Oral Capsule [Marinol]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>53097057360</Code>

--- a/20170701/lord-voldemort-1997-06-26.xml
+++ b/20170701/lord-voldemort-1997-06-26.xml
@@ -264,7 +264,7 @@
         <DrugDescription>carisoprodol 350 MG Oral Tablet [Vanadom]</DrugDescription>
         <DrugCoded>
           <ProductCode>
-            <Code>69036092035	</Code>
+            <Code>69036092035</Code>
             <Qualifier>ND</Qualifier>
           </ProductCode>
         </DrugCoded>
@@ -336,7 +336,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	dronabinol 10 MG Oral Capsule [Marinol]</DrugDescription>
+        <DrugDescription>dronabinol 10 MG Oral Capsule [Marinol]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>53097057360</Code>

--- a/20170701/marcus-aurelius-1975-06-17.xml
+++ b/20170701/marcus-aurelius-1975-06-17.xml
@@ -261,7 +261,7 @@
         </HistorySource>
       </MedicationDispensed>
            <MedicationDispensed>
-        <DrugDescription>Fentanyl Transdermal System, 0.025 mg/hr </DrugDescription>
+        <DrugDescription>Fentanyl Transdermal System, 0.025 mg/hr</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>61919060205</Code>

--- a/20170701/opioid-errors-1974-09-01.xml
+++ b/20170701/opioid-errors-1974-09-01.xml
@@ -636,7 +636,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	1 ML meperidine hydrochloride 100 MG/ML Prefilled Syringe [Demerol]</DrugDescription>
+        <DrugDescription>1 ML meperidine hydrochloride 100 MG/ML Prefilled Syringe [Demerol]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>00409137711</Code>

--- a/20170701/quartre-val-1964-07-29.xml
+++ b/20170701/quartre-val-1964-07-29.xml
@@ -186,7 +186,7 @@
         </HistorySource>
       </MedicationDispensed>
       <MedicationDispensed>
-        <DrugDescription>butorphanol 10 MG/ML </DrugDescription>
+        <DrugDescription>butorphanol 10 MG/ML</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>58198004701</Code>

--- a/20170701/quartre-val-1964-07-29.xml
+++ b/20170701/quartre-val-1964-07-29.xml
@@ -411,7 +411,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	lasmiditan 100 MG Oral Tablet [Reyvow]</DrugDescription>
+        <DrugDescription>lasmiditan 100 MG Oral Tablet [Reyvow]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>00002449161</Code>
@@ -561,7 +561,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	levorphanol tartrate 2 MG Oral Tablet</DrugDescription>
+        <DrugDescription>levorphanol tartrate 2 MG Oral Tablet</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>69543041710</Code>

--- a/20170701/sept-val-1964-07-29.xml
+++ b/20170701/sept-val-1964-07-29.xml
@@ -561,7 +561,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	0.5 ML testosterone enanthate 150 MG/ML [Xyosted] </DrugDescription>
+        <DrugDescription>0.5 ML testosterone enanthate 150 MG/ML [Xyosted] </DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>54436027504</Code>
@@ -861,7 +861,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	diazepam 10 MG Oral Tablet [Valium]</DrugDescription>
+        <DrugDescription>diazepam 10 MG Oral Tablet [Valium]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>00140000635</Code>

--- a/20170701/sigmund-freud-1956-05-06.xml
+++ b/20170701/sigmund-freud-1956-05-06.xml
@@ -264,7 +264,7 @@
         <DrugDescription>armodafinil 150 MG Oral Tablet [Nuvigil]</DrugDescription>
         <DrugCoded>
           <ProductCode>
-            <Code>63459021530	</Code>
+            <Code>63459021530</Code>
             <Qualifier>ND</Qualifier>
           </ProductCode>
         </DrugCoded>

--- a/20170701/six-val-1964-07-29.xml
+++ b/20170701/six-val-1964-07-29.xml
@@ -786,7 +786,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	remifentanil 1 MG Injection [Ultiva]</DrugDescription>
+        <DrugDescription>remifentanil 1 MG Injection [Ultiva]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>67457019803</Code>
@@ -861,7 +861,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	remimazolam 20 MG Injection [Byfavo]</DrugDescription>
+        <DrugDescription>remimazolam 20 MG Injection [Byfavo]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>71390001111</Code>
@@ -936,7 +936,7 @@
         </HistorySource>
       </MedicationDispensed>
        <MedicationDispensed>
-        <DrugDescription>	methylphenidate hydrochloride 20 MG Oral Tablet [Ritalin]</DrugDescription>
+        <DrugDescription>methylphenidate hydrochloride 20 MG Oral Tablet [Ritalin]</DrugDescription>
         <DrugCoded>
           <ProductCode>
             <Code>00078044105</Code>


### PR DESCRIPTION
Remove trailing space in XML elements with:

    find -name "*.xml" -exec sed -E -e 's|([[:alnum:]])[[:space:]]+</|\1</|g' -i {}

Remove leading space in XML elements with:

    find -name "*.xml" -exec sed -E -e 's/>[[:space:]]+([[:alnum:]])/>\1/g' -i {}

Add linting for:
  - Invalid XML
  - Leading/trailing whitespace inside an XML tag (eg `<ProductCode>    13107005530  </ProductCode>`)