### PR TITLE
Functional version of workflow to run timewarp on the PDMP-MOCK-DATA

### DIFF
--- a/.github/workflows/daily_timewarp.yaml
+++ b/.github/workflows/daily_timewarp.yaml
@@ -30,18 +30,17 @@ jobs:
       - name: run timewarp script, push values out one day's time
         run: python bin/timewarp.py --days=1
 
-      - name: Commit and push changes
+      - name: Set up Git credentials
         run: |
-          git status
-          git branch -vv
-          git diff
-          git diff --staged
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/uwcirg/pdmp-mock-data.git
 
+      - name: Commit and push changes
+        run: |
           git add .
           git commit -m "Automated daily update" || echo "No changes to commit"
-          git push origin main
+          git push origin cron-test-branch
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Uses GitHub Actions token

--- a/.github/workflows/daily_timewarp.yaml
+++ b/.github/workflows/daily_timewarp.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: cron-test-branch
+          ref: main
           persist-credentials: false  # prevents accidental overwrites
 
       - name: Setup python for timewarp script
@@ -40,7 +40,7 @@ jobs:
         run: |
           git add .
           git commit -m "Automated daily update" || echo "No changes to commit"
-          git push origin cron-test-branch
+          git push origin main
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Uses GitHub Actions token


### PR DESCRIPTION

NB - had to commit an earlier version of .github/workflows/daily_timewarp.yaml to `main` in order for the workflow to be available for manual runs:
>  the workflow must exist on the default branch for the "Run workflow" button to appear.

This is currently pushing changes to a soon to prune `cron-test-branch`.  Will set to `main` once approved before merging.